### PR TITLE
Add API keys to strings.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,11 +36,11 @@
 
 		<framework custom="true" src="lib/ios/Dropbox.framework"/>
 
-        <config-file target="*-Info.plist" parent="APP_KEY">
+        <config-file target="*-Info.plist" parent="DropboxAppKey">
             <string>$APP_KEY</string>
         </config-file>
 
-        <config-file target="*-Info.plist" parent="APP_SECRET">
+        <config-file target="*-Info.plist" parent="DropboxAppSecret">
             <string>$APP_SECRET</string>
         </config-file>
 
@@ -60,8 +60,8 @@
 
 	<platform name="android">
 		<config-file target="res/values/strings.xml" parent="/*">
-			<string name="app_key">$APP_KEY</string>
-    	    <string name="app_secret">$APP_SECRET</string>
+			<string name="dropbox_app_key">$APP_KEY</string>
+    	    <string name="dropbox_app_secret">$APP_SECRET</string>
 	    </config-file>
 
 		<config-file target="res/xml/config.xml" parent="/*">

--- a/plugin.xml
+++ b/plugin.xml
@@ -59,13 +59,10 @@
 
 
 	<platform name="android">
-
-		<source-file src="src/android/res/values/dropbox.xml" target-dir="res/values" />
-
-		<config-file target="res/values/dropbox.xml" parent="/*">
-				<string name="app_key">$APP_KEY</string>
-        <string name="app_secret">$APP_SECRET</string>
-    </config-file>
+		<config-file target="res/values/strings.xml" parent="/*">
+			<string name="app_key">$APP_KEY</string>
+    	    <string name="app_secret">$APP_SECRET</string>
+	    </config-file>
 
 		<config-file target="res/xml/config.xml" parent="/*">
 			<feature name="Dropbox">

--- a/src/android/DropboxPlugin.java
+++ b/src/android/DropboxPlugin.java
@@ -29,10 +29,10 @@ public class DropboxPlugin extends CordovaPlugin {
 	protected void pluginInitialize() {
 		Context context= this.cordova.getActivity().getApplicationContext();
 
-		int appResId = cordova.getActivity().getResources().getIdentifier("app_key", "string", cordova.getActivity().getPackageName());
+		int appResId = cordova.getActivity().getResources().getIdentifier("dropbox_app_key", "string", cordova.getActivity().getPackageName());
 		String appKey = cordova.getActivity().getString(appResId);
 
-		appResId = cordova.getActivity().getResources().getIdentifier("app_secret", "string", cordova.getActivity().getPackageName());
+		appResId = cordova.getActivity().getResources().getIdentifier("dropbox_app_secret", "string", cordova.getActivity().getPackageName());
 
 		String appSecret = cordova.getActivity().getString(appResId);
 

--- a/src/android/res/values/dropbox.xml
+++ b/src/android/res/values/dropbox.xml
@@ -1,3 +1,0 @@
-<?xml version='1.0' encoding='utf-8'?>
-<resources>
-</resources>

--- a/src/ios/AppDelegate+dropbox.m
+++ b/src/ios/AppDelegate+dropbox.m
@@ -45,8 +45,8 @@
 - (void)initDropbox:(NSNotification *)notification
 {
     if (notification){
-        NSString *appKey = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"APP_KEY"];
-        NSString *appSecret = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"APP_SECRET"];
+        NSString *appKey = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"DropboxAppKey"];
+        NSString *appSecret = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"DropboxAppSecret"];
 
         DBAccountManager *accountManager = [[DBAccountManager alloc] initWithAppKey:appKey secret:appSecret];
         [DBAccountManager setSharedManager:accountManager];


### PR DESCRIPTION
- Avoiding copying and modifying resource files from plugin as modification leaks into its source directory when installed as symlink.
- Prefix resource identifiers to avoid potential conflicts with other plugins

ping @EddyVerbruggen 
